### PR TITLE
Dynamic component loading draft

### DIFF
--- a/docs/dynamic-component-loading.md
+++ b/docs/dynamic-component-loading.md
@@ -87,5 +87,6 @@ The second overload adds the ability to specify:
 * Section about interactions of the new ALC with existing extension points of the binder (various events on `Assembly`, `AppDomain` and `AssemblyLoadContext`, interaction with other ALCs, native asset resolution extension points ...)
 * More details on native asset resolution
 * More details on satellite assembly resolution
+* Handling of R2R images (NI)
 * Possible further improvements
   * Recommended way to express app requirements for a given component. So that a generic app can implement "plugin picker" and only show compatible "plugins". Could be just a set of recommendations, or maybe a section in `.deps.json` with the appropriate managed API to read/write to it.

--- a/docs/dynamic-component-loading.md
+++ b/docs/dynamic-component-loading.md
@@ -16,16 +16,16 @@ List of few scenarios where dynamic loading of full components is required:
 * XUnit loading tests - the test runner acts as an app and the test is loaded dynamically. The test can have any number of dependencies. Finding and resolving those dependencies is challenging.
 * ASP .NET's `dotnet watch` - ability to dynamically reload an app without restarting the process. Each version of the app is inherently in collision with any previous version. The old version should be unloaded.
 
-In lot of these cases the component which is to be loaded dynamically has a non-trivial amount of dependencies which are unknown to the app itself. So the loading mechanism has to be able to resolve them.
+In lot of these cases the component which is to be loaded dynamically has a non-trivial set of dependencies which are unknown to the app itself. So the loading mechanism has to be able to resolve them.
 
 ## Declaring dependencies
 The .NET Core SDK tooling produces `.deps.json` which is a dependency manifest for dotnet apps. It enables components (or apps) to load dependencies from locations other than the base directory (ex: from packages, platform-specific publish directories, etc.)  
 .NET Core first builds a set of directories to look for binaries (called ProbingPaths) based on application/component base directory, framework directory, `.runtimeconfig.dev.json`, command line, servicing locations, etc. For more details see [host-probing](https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/host-probing.md).
 
-
 For an application or component, the `.deps.json` file specifies:
-•	A set of binary dependencies -- which are searched within ProbingPaths
-•	Relative paths to locate them -- relative paths in `.deps.json` file can be used to locate architecture-specific dependencies within publish/package directories.
+* A set of binary dependencies -- which are searched within ProbingPaths
+* Relative paths to locate them -- relative paths in `.deps.json` file can be used to locate architecture-specific dependencies within publish/package directories.
+
 If the app depends on any frameworks, the `.deps.json` files of those framework are similarly processed.
 Further details about the algorithm used for processing dependencies can be found in [assembly-conflict-resolution](
 https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/assembly-conflict-resolution.md).
@@ -87,3 +87,5 @@ The second overload adds the ability to specify:
 * Section about interactions of the new ALC with existing extension points of the binder (various events on `Assembly`, `AppDomain` and `AssemblyLoadContext`, interaction with other ALCs, native asset resolution extension points ...)
 * More details on native asset resolution
 * More details on satellite assembly resolution
+* Possible further improvements
+  * Recommended way to express app requirements for a given component. So that a generic app can implement "plugin picker" and only show compatible "plugins". Could be just a set of recommendations, or maybe a section in `.deps.json` with the appropriate managed API to read/write to it.

--- a/docs/dynamic-component-loading.md
+++ b/docs/dynamic-component-loading.md
@@ -76,3 +76,4 @@ The second overload adds the ability to specify:
 * Section about settings/config knobs - env. variables, roll forward settings, command line arguments - which will have effect of component loading and which will be ignored and how.
 * Section about interactions of the new ALC with existing extension points of the binder (various events on `Assembly`, `AppDomain` and `AssemblyLoadContext`, interaction with other ALCs, native asset resolution extension points ...)
 * More details on native asset resolution
+* More details on satellite assembly resolution

--- a/docs/dynamic-component-loading.md
+++ b/docs/dynamic-component-loading.md
@@ -1,0 +1,48 @@
+# Dynamic component loading
+
+## Problem statement
+.NET Core runtime has only limited support for dynamically loading assemblies which have additional dependencies or possibly collide with the app in any way. Out of the box only these scenarios really work:
+* Assemblies which have no additional dependencies other than those find in the app itself (`Assembly.Load` and `Assembly.LoadFrom`)
+* Assemblies which have additional dependencies in the same folder and which don't collide with anything in the app itself (`Assembly.LoadFrom`)
+* Loading a single assembly in full isolation (from the app), but all its dependencies must come from the app (`Assembly.LoadFile`)
+
+Other scenarios are technically supported by implementing a custom `AssemblyLoadContext` but doing so is complex.  
+Additionally, there's no inherent synergy with the .NET Core SDK tooling. Components produced by the SDK can't be easily loaded at runtime.
+
+## Scenarios
+List of few scenarios where dynamic loading of full components is required:
+* MSBuild tasks - all tasks in MSBuild are dynamically loaded. Some tasks come with additional dependencies which can collide with each other or MSBuild itself as well.
+* Roslyn analyzers - similar to MSBuild tasks, the Roslyn compiler dynamically loads analyzers which are separate components with potentially conflicting dependencies.
+* XUnit loading tests - the test runner acts as an app and the test is loaded dynamically. The test can have any number of dependencies. Finding and resolving those dependencies is challenging.
+* ASP .NET's `dotnet watch` - ability to dynamically reload an app without restarting the process. Each version of the app is inherently in collision with any previous version. The old version should be unloaded.
+
+In lot of these cases the component which is to be loaded dynamically has a non-trivial amount of dependencies which are unknown to the app itself. So the loading mechanism has to be able to resolve them.  
+The SDK tooling uses the `.deps.json` format to describe dependencies of a component, so it would be beneficial if the dynamic load was able to use this same format for dependency resolution.
+
+## Dynamic loading with dependencies
+We propose to add a new public API which would dynamically load a component with these properties:
+* Component is loaded in isolation from the app (and other components) so that potential collisions are not an issue
+* Component can use `.deps.json` to describe its dependencies. This includes the ability to describe additional NuGet packages, RID-specific and/or native dependencies.
+* Component can chose to rely on the app for certain dependencies by not including them in its `.deps.json`
+* Optionally such component can be enabled for unloading
+
+Public API (early thinking):
+* `static Assembly Assembly.LoadFileWithDependencies` - in its core similar to `Assembly.LoadFile` but it supports resolving dependencies through `.deps.json` and such. Just like `Assembly.LoadFile` it provides isolation, but also for the dependencies.
+* `static AssemblyLoadContext AssemblyLoadContext.CreateForAssemblyWithDependencies(string assemblyPath)` - "advanced" version which would return an ALC instance and not just the main assembly. Could have overloads for enabling unloadability.
+
+## High-level description of the solution
+* Implement a new `AssemblyLoadContext` which will provide the isolation boundary and act as the "root" for the component. It can be enabled for unloading.  
+* The new load context is initialized by specifying the full path to the main assembly of the component to load.  
+* It will look for the `.deps.json` next to that assembly to determine its dependencies. Lack of `.deps.json` will be treated in the same way it is today for executable apps - that is all the assemblies in the same folder will be used as dependencies.
+* Parsing and understanding of the `.deps.json` will be performed by the same host components which do this for executable apps (so same behavior/quirks/bugs, very little code duplication).
+* If the component has `.runtimeconfig.json` it will only be used to verify runtime version and provide probing paths.
+* The load context will determine a list of assemblies similar to TPA and list of native search paths. These will be used to resolve any assembly binding events in the load context.
+* If the load context can't resolve an assembly bind event, it will fallback to the parent load context (the app)
+
+## Important implications and limitations
+* Only framework dependent components will be supported. Self-contained components will not be supported even if there was a way to produce them.
+* The host (the app) can be any configuration (framework dependent or self-contained). The notion of frameworks is completely ignored by this new functionality.
+* All framework dependencies of the component must be resolvable by the app - simply put, the component must use the same frameworks as the app.
+* Components can't add frameworks to the app - the app must "pre-load" all necessary frameworks.
+* By default only framework types will be shared between the app and the component. The component may chose to share more by not including dependencies in the component (`CopyLocal=false`).
+* Pretty much all settings in `.runtimeconfig.json` and `.runtimeconfig.dev.json` will be ignored with the exception of runtime version (probably done through TFM) and additional probing paths.

--- a/docs/dynamic-component-loading.md
+++ b/docs/dynamic-component-loading.md
@@ -75,12 +75,12 @@ The second overload adds the ability to specify:
 
 ## Handling of various asset types
 What happens with various asset types once the ALC decides to load it in isolation.
-* Normal managed assembly (code) - The `.deps.json` parsing code will return list of full file paths. The ALC will just find it there and load it.
+* Normal managed assembly (code) - The `.deps.json` parsing code will return list of full file paths. The ALC will just find it there and load it.  
+Note that R2R images are handled by this as well since they are basically just a slightly different managed assembly.
 * Satellite assemblies (resources) - Two possibilities:
     * Imitate app behavior exactly - `.deps.json` only provides list of resource probing paths. ALC would then try to find the `<culture>/AssemblyName.dll` in each probing path and resolve the first match.
     * Use full paths - `.deps.json` resolution actually internally produces a list of full file paths and then trims it to just probing paths. The full file paths could be used by the ALC in a very similar manner to code assemblies.
 * Native libraries - To integrate well the ALC would only get list of native probing paths from the `.deps.json`. It would then use new API to load native library given a probing path and a simple name. Internally this would call into the existing runtime behavior (which tries various prefix/suffix combinations and so on).
-* R2R Images (NI images) - The same list of full paths as for managed assemblies may contain NI images (recognized by file extension). NI images take priority over IL images always. ALC will load the NI image.
 
 ## Important implications and limitations
 * Only framework dependent components will be supported. Self-contained components will not be supported even if there was a way to produce them.

--- a/docs/dynamic-component-loading.md
+++ b/docs/dynamic-component-loading.md
@@ -76,7 +76,7 @@ The second overload adds the ability to specify:
 ## Handling of various asset types
 What happens with various asset types once the ALC decides to load it in isolation.
 * Normal managed assembly (code) - The `.deps.json` parsing code will return list of full file paths. The ALC will just find it there and load it.  
-Note that R2R images are handled by this as well since they are basically just a slightly different managed assembly.
+Note that R2R images are handled by this as well since they are basically just a slightly different managed assembly. Also note that .NET Core can only load a given R2R image once as R2R. Any subsequent load of the same file will work, but it will be only read as a pure IL assembly (and thus require JITing). Loading the same file multiple times can occur if two load contexts decide to load the assembly in isolation.
 * Satellite assemblies (resources) - Two possibilities:
     * Imitate app behavior exactly - `.deps.json` only provides list of resource probing paths. ALC would then try to find the `<culture>/AssemblyName.dll` in each probing path and resolve the first match.
     * Use full paths - `.deps.json` resolution actually internally produces a list of full file paths and then trims it to just probing paths. The full file paths could be used by the ALC in a very similar manner to code assemblies.


### PR DESCRIPTION
Very first draft of the "plugin" design.

TODOs:
- [x] Short description of .deps.json functionality - to demonstrate the capabilities we'll enable by using it.
- [ ] Section about expected tooling experiences - what does it mean to build a "plugin" using .NET SDK and so on.
- [ ] Section about settings/config knobs - env. variables, roll forward settings, command line arguments  - which will have effect of component loading and which will be ignored and how.
- [ ] Section about interactions of the new ALC with existing extension points of the binder (various events on `Assembly`, `AppDomain` and `AssemblyLoadContext`, interation with other ALCs, native asset resolution extension points ...)
- [x] More details on native asset resolution
- [x] More details on satellite assembly resolution
- [x] Handling of NI images